### PR TITLE
Remove requirement from navpage tagline prop

### DIFF
--- a/src/components/navigation/NavPage.jsx
+++ b/src/components/navigation/NavPage.jsx
@@ -21,7 +21,7 @@ function NavPage(props) {
 NavPage.propTypes = {
   id: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
-  tagline: PropTypes.string.isRequired,
+  tagline: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.element),
     PropTypes.object,


### PR DESCRIPTION
Having tagline set as required  was throwing a warning in the console:
<img width="808" alt="Screenshot 2024-05-07 at 4 58 18 PM" src="https://github.com/art-institute-of-chicago/my-museum-tour/assets/2098951/5cdd73f5-4405-4712-a58b-a428a30c8c1e">
