### PR TITLE
Remove null coalesce operator

### DIFF
--- a/dist/MyMuseumTourBuilder.js
+++ b/dist/MyMuseumTourBuilder.js
@@ -234,7 +234,7 @@ function L(i, a) {
   ), n.searchParams.set("query[bool][minimum_should_match]", "1"), n.searchParams.set(
     "fields",
     "artist_title,short_description,description,id,image_id,thumbnail,title,date_display,gallery_title,gallery_id"
-  ), n.searchParams.set("limit", "60"), n.searchParams.set("page", i.page ?? 1), typeof i.keywords < "u" && n.searchParams.set("q", i.keywords), a)
+  ), n.searchParams.set("limit", "60"), typeof i.page < "u" && n.searchParams.set("page", i.page), typeof i.keywords < "u" && n.searchParams.set("q", i.keywords), a)
     for (const r of Object.values(a))
       n.searchParams.set(
         `query[bool][must_not][][term][id][value]=${r}`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,9 @@ export function createSearchUrl(queryParams, hideFromTours) {
     "artist_title,short_description,description,id,image_id,thumbnail,title,date_display,gallery_title,gallery_id",
   );
   url.searchParams.set("limit", "60");
-  url.searchParams.set("page", queryParams.page ?? 1);
+  if (typeof queryParams.page !== "undefined") {
+    url.searchParams.set("page", queryParams.page);
+  }
   if (typeof queryParams.keywords !== "undefined") {
     url.searchParams.set("q", queryParams.keywords);
   }


### PR DESCRIPTION
When running the `npm run production` compilation step during a deploy, webpack chokes on the null coalesce operator, so I've removed it in favor of a type check.